### PR TITLE
Resolve ts-node Path Resolution Issue with tsconfig-paths

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -39,6 +39,7 @@
     "mocha": "^10.2.0",
     "nodemon": "^3.0.1",
     "prettier": "^3.2.4",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0"
   }
 }

--- a/app/backend/src/api/Api.ts
+++ b/app/backend/src/api/Api.ts
@@ -1,21 +1,21 @@
 import express from "express";
-import Logger from "../tools/Logger";
-import { apiLogger } from "./middleware/apiLogger";
-import { Database } from "../database/Database";
-import { createHealthRouter } from "./routers/HealthRouter";
-import HealthController from "./controllers/HealthController";
-import { MetadataController } from "../api/controllers/MetadataController";
-import MetadataRepository from "../database/repositories/MetadataRepository";
-import { createMetadataRouter } from "../api/routers/MetadataRouter";
-import { SyncStatusController } from "../api/controllers/SyncStatusController";
-import SyncStatusRepository from "../database/repositories/SyncStatusRepository";
-import { createSyncStatusRouter } from "../api/routers/SyncStatusRouter";
-import { PricingController } from "../api/controllers/PriceController";
-import { PriceRepository } from "../database/repositories/PricingRepository";
-import { createPricingRouter } from "../api/routers/PriceRouter";
-import { createBlockValueRouter } from "../api/routers/BlockValueRouter";
-import { BlockValueController } from "../api/controllers/BlockValueController";
-import BlockValueRepository from "../database/repositories/BlockValueRepository";
+import Logger from "@/tools/Logger";
+import { apiLogger } from "@/api/middleware/apiLogger";
+import { Database } from "@/database/Database";
+import { createHealthRouter } from "@/api/routers/HealthRouter";
+import HealthController from "@/api/controllers/HealthController";
+import { MetadataController } from "@/api/controllers/MetadataController";
+import MetadataRepository from "@/database/repositories/MetadataRepository";
+import { createMetadataRouter } from "@/api/routers/MetadataRouter";
+import { SyncStatusController } from "@/api/controllers/SyncStatusController";
+import SyncStatusRepository from "@/database/repositories/SyncStatusRepository";
+import { createSyncStatusRouter } from "@/api/routers/SyncStatusRouter";
+import { PricingController } from "@/api/controllers/PriceController";
+import { PriceRepository } from "@/database/repositories/PricingRepository";
+import { createPricingRouter } from "@/api/routers/PriceRouter";
+import { createBlockValueRouter } from "@/api/routers/BlockValueRouter";
+import { BlockValueController } from "@/api/controllers/BlockValueController";
+import BlockValueRepository from "@/database/repositories/BlockValueRepository";
 
 export class Api {
   private readonly app: express.Application;

--- a/app/backend/src/api/controllers/BlockValueController.ts
+++ b/app/backend/src/api/controllers/BlockValueController.ts
@@ -2,12 +2,12 @@ import { Request, Response } from "express";
 import {
   BlockValueRepository,
   chainTableMapping,
-} from "../../database/repositories/BlockValueRepository";
+} from "@/database/repositories/BlockValueRepository";
 import {
   sendErrorResponse,
   sendSuccessResponse,
-} from "../../api/utils/responseUtils";
-import Logger from "../../tools/Logger";
+} from "@/api/utils/responseUtils";
+import Logger from "@/tools/Logger";
 
 export class BlockValueController {
   private blockValueRepository: BlockValueRepository;

--- a/app/backend/src/api/controllers/MetadataController.ts
+++ b/app/backend/src/api/controllers/MetadataController.ts
@@ -1,7 +1,10 @@
 import { MetadataRepository } from "@/database/repositories/MetadataRepository";
 import Logger from "@/tools/Logger";
 import { Request, Response } from "express";
-import { sendErrorResponse, sendSuccessResponse } from "../utils/responseUtils";
+import {
+  sendErrorResponse,
+  sendSuccessResponse,
+} from "@/api/utils/responseUtils";
 
 export class MetadataController {
   private metadataRepository: MetadataRepository;

--- a/app/backend/src/api/controllers/PriceController.ts
+++ b/app/backend/src/api/controllers/PriceController.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from "express";
 import { PriceRepository } from "@/database/repositories/PricingRepository"; // Adjust the import path as necessary
-import { sendErrorResponse, sendSuccessResponse } from "../utils/responseUtils";
+import {
+  sendErrorResponse,
+  sendSuccessResponse,
+} from "@/api/utils/responseUtils";
 import Logger from "@/tools/Logger";
 
 type Price = {

--- a/app/backend/src/api/controllers/SyncStatusController.ts
+++ b/app/backend/src/api/controllers/SyncStatusController.ts
@@ -1,8 +1,11 @@
 import { SyncStatusRepository } from "@/database/repositories/SyncStatusRepository";
 import Logger from "@/tools/Logger";
 import { Request, Response } from "express";
-import { sendErrorResponse, sendSuccessResponse } from "../utils/responseUtils";
-import { chainTableMapping } from "../../database/repositories/BlockValueRepository";
+import {
+  sendErrorResponse,
+  sendSuccessResponse,
+} from "@/api/utils/responseUtils";
+import { chainTableMapping } from "@/database/repositories/BlockValueRepository";
 
 export class SyncStatusController {
   private syncStatusRepository: SyncStatusRepository;

--- a/app/backend/src/api/routers/HealthRouter.ts
+++ b/app/backend/src/api/routers/HealthRouter.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { HealthController } from "../controllers/HealthController";
+import { HealthController } from "@/api/controllers/HealthController";
 
 export function createHealthRouter(healthController: HealthController): Router {
   const router: Router = Router();

--- a/app/backend/src/api/routers/MetadataRouter.ts
+++ b/app/backend/src/api/routers/MetadataRouter.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { MetadataController } from "../controllers/MetadataController";
+import { MetadataController } from "@/api/controllers/MetadataController";
 
 export function createMetadataRouter(
   metadataController: MetadataController,

--- a/app/backend/src/api/routers/PriceRouter.ts
+++ b/app/backend/src/api/routers/PriceRouter.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { PricingController } from "../controllers/PriceController"; // Adjust the import path as necessary
+import { PricingController } from "@/api/controllers/PriceController"; // Adjust the import path as necessary
 
 export function createPricingRouter(
   pricingController: PricingController,

--- a/app/backend/src/api/routers/SyncStatusRouter.ts
+++ b/app/backend/src/api/routers/SyncStatusRouter.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { SyncStatusController } from "../controllers/SyncStatusController";
+import { SyncStatusController } from "@/api/controllers/SyncStatusController";
 
 export function createSyncStatusRouter(
   syncStatusController: SyncStatusController,

--- a/app/backend/src/config/config.local.ts
+++ b/app/backend/src/config/config.local.ts
@@ -7,7 +7,7 @@ import {
   OptimismModuleConfig,
   PricingModuleConfig,
 } from "./Config";
-import { Env } from "../tools/Env";
+import { Env } from "@/tools/Env";
 
 export function getLocalConfig(env: Env): Config {
   const databaseConfig: DatabaseConfig = {

--- a/app/backend/src/config/config.test.ts
+++ b/app/backend/src/config/config.test.ts
@@ -7,7 +7,7 @@ import {
   OptimismModuleConfig,
   PricingModuleConfig,
 } from "./Config";
-import { Env } from "../tools/Env";
+import { Env } from "@/tools/Env";
 
 export function getTestConfig(env: Env): Config {
   const databaseConfig: DatabaseConfig = {

--- a/app/backend/src/config/index.ts
+++ b/app/backend/src/config/index.ts
@@ -1,6 +1,6 @@
 import { Config } from "./Config";
 import { getLocalConfig } from "./config.local";
-import { getEnv } from "../tools/Env";
+import { getEnv } from "@/tools/Env";
 import { getTestConfig } from "./config.test";
 
 export type { Config };

--- a/app/backend/src/core/clients/ethereum/EthereumClient.test.ts
+++ b/app/backend/src/core/clients/ethereum/EthereumClient.test.ts
@@ -2,10 +2,9 @@ import EthereumClient from "./EthereumClient";
 import { expect, mockFn } from "earl";
 import { beforeEach } from "mocha";
 import { ethers } from "ethers";
-import Logger from "../../../tools/Logger";
-import { undefined } from "zod";
+import Logger from "@/tools/Logger";
 import contractsData from "./contracts/contracts.json";
-import { getConfig } from "../../../config";
+import { getConfig } from "@/config";
 
 describe(EthereumClient.name, () => {
   let ethClient: EthereumClient;

--- a/app/backend/src/core/controllers/indexers/l1/L1LogMonitorController.ts
+++ b/app/backend/src/core/controllers/indexers/l1/L1LogMonitorController.ts
@@ -1,16 +1,16 @@
-import Logger from "../../../../tools/Logger";
-import EthereumClient from "../../../../core/clients/ethereum/EthereumClient";
-import EthereumLogDecoder from "../../../clients/ethereum/EthereumLogDecoder";
-import contracts from "../../../clients/ethereum/contracts/contracts.json";
+import Logger from "@/tools/Logger";
+import EthereumClient from "@/core/clients/ethereum/EthereumClient";
+import EthereumLogDecoder from "@/core/clients/ethereum/EthereumLogDecoder";
+import contracts from "@/core/clients/ethereum/contracts/contracts.json";
 import { ContractName } from "@/core/clients/ethereum/contracts/types";
 import { Database } from "@/database/Database";
 import MetadataRepository, {
   MetadataJobName,
   MetadataMetricName,
   MetadataRecord,
-} from "../../../../database/repositories/MetadataRepository";
+} from "@/database/repositories/MetadataRepository";
 import { EthereumMonitorConfig } from "@/config/Config";
-import SyncStatusRepository from "../../../../database/repositories/SyncStatusRepository";
+import SyncStatusRepository from "@/database/repositories/SyncStatusRepository";
 import { ethers } from "ethers";
 import { LogProcessors } from "./LogProcessor";
 

--- a/app/backend/src/core/controllers/indexers/l1/LogProcessor.test.ts
+++ b/app/backend/src/core/controllers/indexers/l1/LogProcessor.test.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import { LogProcessors } from "./LogProcessor";
 import { expect } from "earl";
-import contracts from "../../../clients/ethereum/contracts/contracts.json";
+import contracts from "@/core/clients/ethereum/contracts/contracts.json";
 import { ethers } from "ethers";
 import {
   SubmissionType,
   SyncStatusRecord,
-} from "../../../../database/repositories/SyncStatusRepository";
+} from "@/database/repositories/SyncStatusRepository";
 import { OptimismOutputProposed } from "@/core/controllers/indexers/shared/types";
 describe(LogProcessors.name, () => {
   it("should have a callback for every topic in contracts.json", () => {

--- a/app/backend/src/core/controllers/indexers/l1/LogProcessor.ts
+++ b/app/backend/src/core/controllers/indexers/l1/LogProcessor.ts
@@ -1,9 +1,9 @@
 import {
   SubmissionType,
   SyncStatusRecord,
-} from "../../../../database/repositories/SyncStatusRepository";
+} from "@/database/repositories/SyncStatusRepository";
 import { ethers } from "ethers";
-import { ContractName } from "../../../../core/clients/ethereum/contracts/types";
+import { ContractName } from "@/core/clients/ethereum/contracts/types";
 import { OptimismOutputProposed } from "@/core/controllers/indexers/shared/types";
 
 type CallbackFunction = (...args: any[]) => any;

--- a/app/backend/src/core/controllers/indexers/l2/optimism/OptimismBlockController.ts
+++ b/app/backend/src/core/controllers/indexers/l2/optimism/OptimismBlockController.ts
@@ -1,6 +1,6 @@
 import BlockIndexerController, {
   BlockIndexerConfig,
-} from "../../shared/BlockIndexerController";
+} from "@/core/controllers/indexers/shared/BlockIndexerController";
 import OptimismClient from "@/core/clients/optimism/OptimismClient";
 import { Logger } from "@/tools/Logger";
 import { Database } from "@/database/Database";

--- a/app/backend/src/core/controllers/indexers/l2/optimism/OptimismFinalityController.ts
+++ b/app/backend/src/core/controllers/indexers/l2/optimism/OptimismFinalityController.ts
@@ -1,11 +1,11 @@
-import Logger from "../../../../../tools/Logger";
+import Logger from "@/tools/Logger";
 import OptimismClient from "@/core/clients/optimism/OptimismClient";
-import { Database } from "../../../../../database/Database";
-import { OptimismSyncStatus } from "../../../../clients/optimism/types";
+import { Database } from "@/database/Database";
+import { OptimismSyncStatus } from "@/core/clients/optimism/types";
 import SyncStatusRepository, {
   SubmissionType,
   SyncStatusRecord,
-} from "../../../../../database/repositories/SyncStatusRepository";
+} from "@/database/repositories/SyncStatusRepository";
 import { Config } from "@/config";
 
 class OptimismFinalityController {

--- a/app/backend/src/core/controllers/indexers/shared/BlockIndexerController.ts
+++ b/app/backend/src/core/controllers/indexers/shared/BlockIndexerController.ts
@@ -1,6 +1,6 @@
 import { Logger } from "@/tools/Logger";
 import { Database } from "@/database/Database";
-import BlockValueRepository from "../../../../database/repositories/BlockValueRepository";
+import BlockValueRepository from "@/database/repositories/BlockValueRepository";
 
 export interface BlockIndexerConfig {
   chainId: number;

--- a/app/backend/src/core/controllers/pricing/PriceUpdaterController.ts
+++ b/app/backend/src/core/controllers/pricing/PriceUpdaterController.ts
@@ -1,9 +1,9 @@
-import { PriceRepository } from "../../../database/repositories/PricingRepository";
-import { WhitelistedAsset } from "../../../core/clients/coincap/assets/types";
-import whitelisted from "../../clients/coincap/assets/whitelisted.json";
-import CoinCapClient from "./../../clients/coincap/CoinCapClient";
-import { UnixTime } from "../../../core/types/UnixTime";
-import Logger from "../../../tools/Logger";
+import { PriceRepository } from "@/database/repositories/PricingRepository";
+import { WhitelistedAsset } from "@/core/clients/coincap/assets/types";
+import whitelisted from "@/core/clients/coincap/assets/whitelisted.json";
+import CoinCapClient from "@/core/clients/coincap/CoinCapClient";
+import { UnixTime } from "@/core/types/UnixTime";
+import Logger from "@/tools/Logger";
 
 export class PriceUpdaterController {
   private readonly coinCapClient: CoinCapClient;

--- a/app/backend/src/core/modules/indexers/l1/L1LogMonitorModule.ts
+++ b/app/backend/src/core/modules/indexers/l1/L1LogMonitorModule.ts
@@ -1,9 +1,9 @@
 import { Logger } from "@/tools/Logger";
 import { Database } from "@/database/Database";
 import { Config } from "@/config/Config";
-import L1LogMonitorController from "../../../controllers/indexers/l1/L1LogMonitorController";
-import { TaskScheduler } from "../../../../core/scheduler/TaskScheduler";
-import EthereumClient from "../../../../core/clients/ethereum/EthereumClient";
+import L1LogMonitorController from "@/core/controllers/indexers/l1/L1LogMonitorController";
+import { TaskScheduler } from "@/core/scheduler/TaskScheduler";
+import EthereumClient from "@/core/clients/ethereum/EthereumClient";
 
 export function createL1MonitorModule(
   config: Config,

--- a/app/backend/src/core/modules/indexers/l2/optimism/OptimismBlockModule.ts
+++ b/app/backend/src/core/modules/indexers/l2/optimism/OptimismBlockModule.ts
@@ -1,9 +1,9 @@
 import { Logger } from "@/tools/Logger";
 import { Database } from "@/database/Database";
-import { Config } from "../../../../../config/Config";
-import { TaskScheduler } from "../../../../../core/scheduler/TaskScheduler";
-import OptimismClient from "../../../../../core/clients/optimism/OptimismClient";
-import OptimismBlockController from "../../../../../core/controllers/indexers/l2/optimism/OptimismBlockController";
+import { Config } from "@/config/Config";
+import { TaskScheduler } from "@/core/scheduler/TaskScheduler";
+import OptimismClient from "@/core/clients/optimism/OptimismClient";
+import OptimismBlockController from "@/core/controllers/indexers/l2/optimism/OptimismBlockController";
 
 export function createOptimismBlockModule(
   config: Config,

--- a/app/backend/src/core/modules/indexers/l2/optimism/OptimismFinalityModule.ts
+++ b/app/backend/src/core/modules/indexers/l2/optimism/OptimismFinalityModule.ts
@@ -1,8 +1,8 @@
 import { Logger } from "@/tools/Logger";
 import { Database } from "@/database/Database";
 import { Config } from "@/config/Config";
-import OptimismClient from "../../../../../core/clients/optimism/OptimismClient";
-import OptimismFinalityController from "../../../../../core/controllers/indexers/l2/optimism/OptimismFinalityController";
+import OptimismClient from "@/core/clients/optimism/OptimismClient";
+import OptimismFinalityController from "@/core/controllers/indexers/l2/optimism/OptimismFinalityController";
 
 export function createOptimismFinalityModule(
   config: Config,

--- a/app/backend/src/core/modules/pricing/PriceUpdaterModule.ts
+++ b/app/backend/src/core/modules/pricing/PriceUpdaterModule.ts
@@ -1,9 +1,9 @@
 import Logger from "@/tools/Logger";
 import { Database } from "@/database/Database";
 import CoinCapClient from "@/core/clients/coincap/CoinCapClient";
-import { PriceUpdaterController } from "../../controllers/pricing/PriceUpdaterController";
-import { PriceRepository } from "../../../database/repositories/PricingRepository";
-import TaskScheduler from "../../../core/scheduler/TaskScheduler";
+import { PriceUpdaterController } from "@/core/controllers/pricing/PriceUpdaterController";
+import { PriceRepository } from "@/database/repositories/PricingRepository";
+import TaskScheduler from "@/core/scheduler/TaskScheduler";
 import { Config } from "@/config/Config";
 
 export function createPriceUpdaterModule(

--- a/app/backend/src/database/getTestDatabase.ts
+++ b/app/backend/src/database/getTestDatabase.ts
@@ -1,9 +1,9 @@
-import { Env, getEnv } from "../tools/Env";
-import { getTestConfig } from "../config/config.test";
+import { Env, getEnv } from "@/tools/Env";
+import { getTestConfig } from "@/config/config.test";
 import { Database } from "./Database";
-import Logger from "../tools/Logger";
+import Logger from "@/tools/Logger";
 import { Knex } from "knex";
-import { Config } from "../config";
+import { Config } from "@/config";
 
 export async function getTestDatabase(): Promise<Knex> {
   const env: Env = getEnv();

--- a/app/backend/src/database/repositories/BlockValueRepository.test.ts
+++ b/app/backend/src/database/repositories/BlockValueRepository.test.ts
@@ -4,9 +4,7 @@ import BlockValueRepository, {
   BlockValueRecord,
   chainTableMapping,
 } from "./BlockValueRepository";
-import { Database } from "@/database/Database";
-import { getTestDatabase } from "../getTestDatabase";
-import { Block } from "ethers";
+import { getTestDatabase } from "@/database/getTestDatabase";
 
 describe(BlockValueRepository.name, () => {
   const chainId: number = 10;

--- a/app/backend/src/database/repositories/MetadataRepository.test.ts
+++ b/app/backend/src/database/repositories/MetadataRepository.test.ts
@@ -5,9 +5,8 @@ import {
   MetadataMetricName,
   MetadataRecord,
   MetadataRepository,
-  TABLE_NAME,
 } from "./MetadataRepository";
-import { getTestDatabase } from "../getTestDatabase";
+import { getTestDatabase } from "@/database/getTestDatabase";
 
 describe(MetadataRepository.name, () => {
   let repository: MetadataRepository;

--- a/app/backend/src/database/repositories/PricingRepository.test.ts
+++ b/app/backend/src/database/repositories/PricingRepository.test.ts
@@ -6,8 +6,8 @@ import {
   PriceRow,
   TABLE_NAME,
 } from "./PricingRepository";
-import { getTestDatabase } from "../getTestDatabase";
-import { UnixTime } from "../../core/types/UnixTime";
+import { getTestDatabase } from "@/database/getTestDatabase";
+import { UnixTime } from "@/core/types/UnixTime";
 
 describe(PriceRepository.name, () => {
   let repository: PriceRepository;

--- a/app/backend/src/database/repositories/PricingRepository.ts
+++ b/app/backend/src/database/repositories/PricingRepository.ts
@@ -1,5 +1,5 @@
 import { Knex } from "knex";
-import { UnixTime } from "../../core/types/UnixTime";
+import { UnixTime } from "@/core/types/UnixTime";
 
 export const TABLE_NAME = "asset_prices";
 

--- a/app/backend/src/database/repositories/SyncStatusRepository.test.ts
+++ b/app/backend/src/database/repositories/SyncStatusRepository.test.ts
@@ -1,5 +1,3 @@
-// src/database/repositories/SyncStatusRepository.test.ts
-
 import { Knex } from "knex";
 import { expect } from "earl";
 import {
@@ -8,7 +6,7 @@ import {
   SyncStatusRepository,
   TABLE_NAME,
 } from "./SyncStatusRepository";
-import { getTestDatabase } from "../getTestDatabase";
+import { getTestDatabase } from "@/database/getTestDatabase";
 
 describe(SyncStatusRepository.name, () => {
   let repository: SyncStatusRepository;

--- a/app/backend/tsconfig.json
+++ b/app/backend/tsconfig.json
@@ -22,4 +22,5 @@
       "@/*": ["src/*"],
     },
   },
+  "ts-node": { "require": ["tsconfig-paths/register"] },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,34 @@
         "mocha": "^10.2.0",
         "nodemon": "^3.0.1",
         "prettier": "^3.2.4",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0"
+      }
+    },
+    "app/backend/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "app/backend/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "app/frontend": {


### PR DESCRIPTION
### Problem:
We encountered an issue where `ts-node` was not respecting the `paths` configuration defined in `tsconfig.json`, leading to module resolution errors for aliases like `@`. This was identified as a limitation of `ts-node`, which does not support the `paths` section from `tsconfig.json` out of the box ([source](https://github.com/TypeStrong/ts-node?tab=readme-ov-file#paths-and-baseurl)).

### Solution:
- Installed `tsconfig-paths` as a development dependency to enable path resolution according to the `paths` configuration in `tsconfig.json`.
- Updated `tsconfig.json` to include a `ts-node` configuration block, requiring `tsconfig-paths/register` to bootstrap the module aliasing support.

### Changes:
- Added `tsconfig-paths` to `devDependencies` in `package.json`.
- Updated `tsconfig.json` with the following configuration:
  ```json
  "ts-node": {
    "require": ["tsconfig-paths/register"]
  }
  ```

